### PR TITLE
Fix misnamed variable in interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -52,7 +52,7 @@ export function appHasMonthlyNotesPluginLoaded(): boolean;
 export function createMonthlyNote(date: Moment): Promise<TFile>;
 export function getMonthlyNote(
   date: Moment,
-  weeklyNotes: Record<string, TFile>
+  monthlyNotes: Record<string, TFile>
 ): TFile;
 export function getAllMonthlyNotes(): Record<string, TFile>;
 export function getMonthlyNoteSettings(): IPeriodicNoteSettings;


### PR DESCRIPTION
I don't really expect you to accept this PR, since I imagine this file is generated. The actual function behind this interface definition appeared to have the right variable name, so maybe this file just needs to be regenerated?