### PR TITLE
[FEAT] Add math to templates

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -17,14 +17,12 @@ export const DEFAULT_WEEKLY_NOTE_FORMAT = "gggg-[W]ww";
 export const DEFAULT_MONTHLY_NOTE_FORMAT = "YYYY-MM";
 
 // Utils
+export type IGranularity = "day" | "week" | "month";
 export function getDateFromFile(
   file: TFile,
-  granularity: "day" | "week" | "month"
+  granularity: IGranularity
 ): Moment | null;
-export function getDateUID(
-  date: Moment,
-  granularity: "day" | "week" | "month"
-): string;
+export function getDateUID(date: Moment, granularity: IGranularity): string;
 export function getTemplateContents(template: string): Promise<string>;
 
 // Daily

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-daily-notes-interface",
-  "version": "0.7.11",
+  "version": "0.8.0",
   "description": "Interface for creating daily notes in Obsidian",
   "author": "liamcain",
   "main": "./dist/main.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-daily-notes-interface",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "description": "Interface for creating daily notes in Obsidian",
   "author": "liamcain",
   "main": "./dist/main.js",

--- a/src/__tests__/daily.spec.ts
+++ b/src/__tests__/daily.spec.ts
@@ -189,9 +189,11 @@ describe.only("createDailyNote", () => {
 {{title}}
 {{yesterday}}
 {{tomorrow}}
+{{date-1d:YYYY-MM-DD}}
 {{date+2d:YYYY-MM-DD}}
 {{date+1M:YYYY-MM-DD}}
 {{date+10y:YYYY-MM-DD}}
+{{date +7d}}
 `);
 
     setDailyConfig({
@@ -210,9 +212,11 @@ describe.only("createDailyNote", () => {
 2021-02-15
 2021-02-14
 2021-02-16
+2021-02-14
 2021-02-17
 2021-03-15
 2031-02-15
+2021-02-22
 `
     );
   });

--- a/src/__tests__/daily.spec.ts
+++ b/src/__tests__/daily.spec.ts
@@ -3,9 +3,8 @@ import * as moment from "moment-timezone";
 import getMockApp, { createFile, createFolder } from "src/testUtils/mockApp";
 
 import * as dailyNotesInterface from "../index";
+import * as vaultUtils from "../vault";
 import { setDailyConfig, setPeriodicNotesConfig } from "../testUtils/utils";
-
-jest.mock("path");
 
 describe("getDailyNoteSettings", () => {
   beforeEach(() => {
@@ -171,5 +170,50 @@ describe("getAllDailyNotes", () => {
       "day-2020-12-02T00:00:00-05:00": fileB,
       "day-2020-12-03T00:00:00-05:00": fileC,
     });
+  });
+});
+
+describe.only("createDailyNote", () => {
+  beforeEach(() => {
+    window.app = getMockApp();
+    window.existingFiles = {};
+    window.moment = moment.bind(null, "2021-02-16T05:20:30+05:00");
+    moment.tz.setDefault("America/New_York");
+  });
+
+  test("replaces all mustaches in template", async () => {
+    const getTemplateContents = jest.spyOn(vaultUtils, "getTemplateContents");
+    getTemplateContents.mockResolvedValue(`
+{{date}}
+{{time}}
+{{title}}
+{{yesterday}}
+{{tomorrow}}
+{{date+2d:YYYY-MM-DD}}
+{{date+1M:YYYY-MM-DD}}
+{{date+10y:YYYY-MM-DD}}
+`);
+
+    setDailyConfig({
+      folder: "/",
+      format: "YYYY-MM-DD",
+      template: "template",
+    });
+
+    await dailyNotesInterface.createDailyNote(window.moment());
+
+    expect(window.app.vault.create).toHaveBeenCalledWith(
+      "/2021-02-15.md",
+      `
+2021-02-15
+19:20
+2021-02-15
+2021-02-14
+2021-02-16
+2021-02-17
+2021-03-15
+2031-02-15
+`
+    );
   });
 });

--- a/src/daily.ts
+++ b/src/daily.ts
@@ -29,8 +29,11 @@ export async function createDailyNote(date: Moment): Promise<TFile> {
     const createdFile = await vault.create(
       normalizedPath,
       templateContents
+        .replace(/{{\s*date\s*}}/gi, filename)
+        .replace(/{{\s*time\s*}}/gi, moment().format("HH:mm"))
+        .replace(/{{\s*title\s*}}/gi, filename)
         .replace(
-          /{{\s*(date|time)(([+-]\d+)([dmyhs]))?\s*:(.*?)}}/gi,
+          /{{\s*(date|time)\s*(([+-]\d+)([dmyhs]))?\s*(:.*)?}}/gi,
           (_, _timeOrDate, calc, timeDelta, unit, momentFormat) => {
             const now = moment();
             const currentDate = date.clone().set({
@@ -41,12 +44,13 @@ export async function createDailyNote(date: Moment): Promise<TFile> {
             if (calc) {
               currentDate.add(parseInt(timeDelta, 10), unit);
             }
-            return currentDate.format(momentFormat.trim());
+
+            if (momentFormat) {
+              return currentDate.format(momentFormat.substring(1).trim());
+            }
+            return currentDate.format(format);
           }
         )
-        .replace(/{{\s*date\s*}}/gi, filename)
-        .replace(/{{\s*time\s*}}/gi, moment().format("HH:mm"))
-        .replace(/{{\s*title\s*}}/gi, filename)
         .replace(
           /{{\s*yesterday\s*}}/gi,
           moment().subtract(1, "day").format(format)

--- a/src/daily.ts
+++ b/src/daily.ts
@@ -33,7 +33,7 @@ export async function createDailyNote(date: Moment): Promise<TFile> {
         .replace(/{{\s*time\s*}}/gi, moment().format("HH:mm"))
         .replace(/{{\s*title\s*}}/gi, filename)
         .replace(
-          /{{\s*(date|time)\s*(([+-]\d+)([dmyhs]))?\s*(:.*)?}}/gi,
+          /{{\s*(date|time)\s*(([+-]\d+)([yqmwdhs]))?\s*(:.*)?}}/gi,
           (_, _timeOrDate, calc, timeDelta, unit, momentFormat) => {
             const now = moment();
             const currentDate = date.clone().set({


### PR DESCRIPTION
Add support for calculating the date. Examples:

```
{{yesterday}}
{{tomorrow}}
{{date-1d:YYYY-MM-DD}} // yesterday
{{date+2d:YYYY-MM-DD}} // in two days
{{date+1M:YYYY-MM-DD}} // next month
{{date+10y:YYYY-MM-DD}} // in 10 years
{{date +7d}} // use default format
```

Supported units:
|Unit|Shorthand|
|--|--|
years | y
quarters | Q
months | M
weeks | w
days | d
hours | h
minutes | m
seconds | s
