### PR TITLE
Fix ISO weekday calculation in weekly note templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules/
 main.js
 dist/
+# Snyk Security Extension - AI Rules (auto-generated)
+.github/instructions/snyk_rules.instructions.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Fixed
+
+- **ISO weekday calculation in weekly notes**: Fixed incorrect date calculation for weekday template placeholders (e.g., `{{sunday:YYYY-MM-DD}}`) when using ISO week formats.
+  - **Problem**: For ISO Week 01 of 2026 (Mon Dec 29 2025 – Sun Jan 4 2026), `{{sunday:YYYY-MM-DD}}` incorrectly rendered as 2025-12-28 (the day before Monday) instead of 2026-01-04 (the actual Sunday within the ISO week).
+  - **Root Cause**: The template replacement logic used locale-based `moment.weekday()` which doesn't align with ISO week boundaries. Sunday was treated as index 0 (start of locale week) instead of day 7 of the ISO week.
+  - **Solution**: Added automatic detection of ISO week formats (formats containing `gggg`, `GGGG`, `ww`, `WW`, `w`, `W`, `e`, or `E` tokens) and switched to `moment.isoWeekday()` for these formats, while maintaining backward compatibility with locale-based formats using the original `moment.weekday()` implementation.
+  - **Files Modified**: `src/weekly.ts`
+    - Added `isISOWeekFormat()` helper function to detect ISO week format strings
+    - Added `getISODayOfWeekNumericalValue()` helper function to map day names to ISO weekday numbers (Monday=1, Sunday=7)
+    - Updated template replacement logic in `createWeeklyNote()` to conditionally use `isoWeekday()` or `weekday()` based on the format
+
+### Technical Details
+
+- **Backward Compatibility**: Non-ISO week formats (custom locale-based formats) continue to work exactly as before
+- **ISO Weekday Mapping**: Monday=1, Tuesday=2, Wednesday=3, Thursday=4, Friday=5, Saturday=6, Sunday=7
+- **Locale Weekday Mapping**: Sunday=0, Monday=1, Tuesday=2, Wednesday=3, Thursday=4, Friday=5, Saturday=6 (varies by locale)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,28 @@
+# Bug Fix: ISO Weekday Calculation
+
+## Problem
+
+The `{{sunday:YYYY-MM-DD}}` template placeholder returns the wrong date for ISO week notes.
+For ISO Week 01 of 2026 (Mon Dec 29 2025 – Sun Jan 4 2026), Sunday renders as 2025-12-28
+(the day before Monday) instead of 2026-01-04 (the day after Saturday).
+
+## Root Cause
+
+In `src/weekly.ts`, the `getDaysOfWeek()` function uses locale-based `moment.weekday()`
+which doesn't handle ISO weeks correctly. Sunday gets index 0 instead of 7.
+
+## Fix Required
+
+For ISO week notes, use `moment.isoWeekday()` instead of `moment.weekday()`:
+
+- Monday = 1, Tuesday = 2, ... Saturday = 6, Sunday = 7
+
+## Key Functions to Modify
+
+- `getDaysOfWeek()`
+- `getDayOfWeekNumericalValue()`
+- Template replacement regex handler (around line using `date.weekday(day)`)
+
+## Files
+
+- `src/weekly.ts`

--- a/src/weekly.ts
+++ b/src/weekly.ts
@@ -33,6 +33,24 @@ export function getDayOfWeekNumericalValue(dayOfWeekName: string): number {
   return getDaysOfWeek().indexOf(dayOfWeekName.toLowerCase());
 }
 
+function isISOWeekFormat(format: string): boolean {
+  // Check if format uses ISO week tokens (gggg, GGGG, ww, WW, w, W, e, E)
+  return /[gGwWEe]/.test(format);
+}
+
+function getISODayOfWeekNumericalValue(dayOfWeekName: string): number {
+  const daysOfWeek: Record<string, number> = {
+    monday: 1,
+    tuesday: 2,
+    wednesday: 3,
+    thursday: 4,
+    friday: 5,
+    saturday: 6,
+    sunday: 7,
+  };
+  return daysOfWeek[dayOfWeekName.toLowerCase()];
+}
+
 export async function createWeeklyNote(date: Moment): Promise<TFile> {
   const { vault } = window.app;
   const { template, format, folder } = getWeeklyNoteSettings();
@@ -68,8 +86,15 @@ export async function createWeeklyNote(date: Moment): Promise<TFile> {
         .replace(
           /{{\s*(sunday|monday|tuesday|wednesday|thursday|friday|saturday)\s*:(.*?)}}/gi,
           (_, dayOfWeek, momentFormat) => {
-            const day = getDayOfWeekNumericalValue(dayOfWeek);
-            return date.weekday(day).format(momentFormat.trim());
+            if (isISOWeekFormat(format)) {
+              // Use ISO weekday for ISO week formats
+              const isoDay = getISODayOfWeekNumericalValue(dayOfWeek);
+              return date.isoWeekday(isoDay).format(momentFormat.trim());
+            } else {
+              // Use locale weekday for non-ISO formats (backward compatibility)
+              const day = getDayOfWeekNumericalValue(dayOfWeek);
+              return date.weekday(day).format(momentFormat.trim());
+            }
           }
         )
     );


### PR DESCRIPTION
## Summary

Fixes incorrect date calculation for weekday template placeholders (e.g., `{{sunday:YYYY-MM-DD}}`) when using ISO week formats.

**Problem:** For ISO Week 01 of 2026 (Mon Dec 29 2025 – Sun Jan 4 2026), `{{sunday:YYYY-MM-DD}}` incorrectly rendered as `2025-12-28` (the day before Monday) instead of `2026-01-04` (the actual Sunday within the ISO week).

**Root Cause:** The template replacement logic used locale-based `moment.weekday()` which doesn't align with ISO week boundaries.

**Solution:**
- Added automatic detection of ISO week formats (formats containing `gggg`, `GGGG`, `ww`, `WW`, `w`, `W`, `e`, or `E` tokens)
- Use `moment.isoWeekday()` for ISO week formats (Monday=1, Sunday=7)
- Maintain backward compatibility with locale-based formats using `moment.weekday()`

## Changes

- **src/weekly.ts**: Added `isISOWeekFormat()` and `getISODayOfWeekNumericalValue()` helper functions, updated template replacement logic
- **CHANGELOG.md**: Created comprehensive changelog documenting the fix
- **CLAUDE.md**: Added bug documentation and fix requirements
- **.gitignore**: Added Snyk security extension rule

## Test Plan

- [x] Test with ISO week format `gggg-[W]ww` for ISO Week 01 of 2026
  - Verify `{{sunday:YYYY-MM-DD}}` renders as `2026-01-04`
  - Verify `{{monday:YYYY-MM-DD}}` renders as `2025-12-29`
- [x] Test with locale-based format to ensure backward compatibility
- [x] Test all weekday placeholders (Monday through Sunday)
- [x] Verify existing weekly notes functionality remains intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)